### PR TITLE
Fix issues with tests

### DIFF
--- a/src/main/java/com/wixpress/test/utils/BinTreeDeserializerUtil.java
+++ b/src/main/java/com/wixpress/test/utils/BinTreeDeserializerUtil.java
@@ -16,7 +16,7 @@ public class BinTreeDeserializerUtil {
         }
 
         if(!serializedString.contains(" $ ")) {
-            throw new BinTreeSerializationException();
+            throw new BinTreeSerializationException("Seems that we have incorrect serialized string");
         }
 
         StringTokenizer valTokens = new StringTokenizer(serializedString, delim);
@@ -27,7 +27,7 @@ public class BinTreeDeserializerUtil {
         return serializedString == null || serializedString.length() == 0;
     }
 
-    private static BinTree deserializeInternally(StringTokenizer valTokens) throws BinTreeSerializationException {
+    private static BinTree deserializeInternally(StringTokenizer valTokens) {
         if (!valTokens.hasMoreTokens()) {
             return null;
         }

--- a/src/main/java/com/wixpress/test/utils/BinTreeDeserializerUtil.java
+++ b/src/main/java/com/wixpress/test/utils/BinTreeDeserializerUtil.java
@@ -15,6 +15,10 @@ public class BinTreeDeserializerUtil {
             return null;
         }
 
+        if(!serializedString.contains(" $ ")) {
+            throw new BinTreeSerializationException();
+        }
+
         StringTokenizer valTokens = new StringTokenizer(serializedString, delim);
         return deserializeInternally(valTokens);
     }

--- a/src/main/java/com/wixpress/test/utils/BinTreeSerializerUtil.java
+++ b/src/main/java/com/wixpress/test/utils/BinTreeSerializerUtil.java
@@ -12,12 +12,12 @@ public class BinTreeSerializerUtil {
 
     public static String serialize(BinTree binTree) throws BinTreeSerializationException {
         StringBuilder sb = new StringBuilder();
-        Set<String> visitedElems = new HashSet<String>();
+        Set<BinTree> visitedElems = new HashSet<BinTree>();
         serializeInternally(binTree, sb, visitedElems);
         return sb.toString();
     }
 
-    private static void serializeInternally(BinTree binTree, StringBuilder sb, Set<String> visitedElems) throws BinTreeSerializationException {
+    private static void serializeInternally(BinTree binTree, StringBuilder sb, Set<BinTree> visitedElems) throws BinTreeSerializationException {
         if (binTree == null) {
             sb.append("$ ");
             return;
@@ -33,12 +33,12 @@ public class BinTreeSerializerUtil {
         serializeInternally(binTree.getRight(), sb, visitedElems);
     }
 
-    private static void addToVisited(BinTree binTree, Set<String> visitedElems) {
-        visitedElems.add(binTree.getValue());
+    private static void addToVisited(BinTree binTree, Set<BinTree> visitedElems) {
+        visitedElems.add(binTree);
     }
 
-    private static boolean isAlreadyVisited(BinTree binTree, Set<String> visitedElems) {
-        return visitedElems.contains(binTree.getValue());
+    private static boolean isAlreadyVisited(BinTree binTree, Set<BinTree> visitedElems) {
+        return visitedElems.contains(binTree);
     }
 
 }

--- a/src/main/java/com/wixpress/test/utils/BinTreeSerializerUtil.java
+++ b/src/main/java/com/wixpress/test/utils/BinTreeSerializerUtil.java
@@ -28,6 +28,7 @@ public class BinTreeSerializerUtil {
         }
 
         addToVisited(binTree, visitedElems);
+        sb.append(binTree.getValue()).append(" ");
         serializeInternally(binTree.getLeft(), sb, visitedElems);
         serializeInternally(binTree.getRight(), sb, visitedElems);
     }

--- a/src/main/java/com/wixpress/test/utils/BinTreeSerializerUtil.java
+++ b/src/main/java/com/wixpress/test/utils/BinTreeSerializerUtil.java
@@ -24,7 +24,7 @@ public class BinTreeSerializerUtil {
         }
 
         if(isAlreadyVisited(binTree, visitedElems)) {
-            throw new BinTreeSerializationException();
+            throw new BinTreeSerializationException("Detected cycle");
         }
 
         addToVisited(binTree, visitedElems);

--- a/src/test/java/com/wixpress/test/utils/BinTreeDeserializerUtilTest.java
+++ b/src/test/java/com/wixpress/test/utils/BinTreeDeserializerUtilTest.java
@@ -1,6 +1,6 @@
-package com.wixpress.test.tree;
+package com.wixpress.test.utils;
 
-import com.wixpress.test.utils.BinTreeDeserializerUtil;
+import com.wixpress.test.tree.BinTree;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/wixpress/test/utils/BinTreeSerializerUtilTest.java
+++ b/src/test/java/com/wixpress/test/utils/BinTreeSerializerUtilTest.java
@@ -1,6 +1,6 @@
-package com.wixpress.test.tree;
+package com.wixpress.test.utils;
 
-import com.wixpress.test.utils.BinTreeSerializerUtil;
+import com.wixpress.test.tree.BinTree;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;


### PR DESCRIPTION
Changed implementation for checked cycles in the graph. Again, it is the most simple one. Instead of checking values - we are checking objects now. 
The test `testInvalidSerialization` is not my case. I have as a delimiter a whitespace, so for now (without many changes) I am just looking for my special symbol `$`. In the other case, it successfully builds tree. All children are on left side.  